### PR TITLE
Add GALA to Golang transpilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 * [c2go](https://github.com/elliotchance/c2go) A tool for transpiling C to Go.
 * [Grumpy](https://github.com/google/grumpy) Grumpy is a Python to Go source code transcompiler and runtime.
+* [GALA](https://github.com/martianoff/gala) A functional programming language that transpiles to Go, adding sealed types, pattern matching, immutability by default, and monads.
 * [Godzilla](https://github.com/jingweno/godzilla) Godzilla is a ES2015 to Go source code transpiler and runtime.
 
 ### Java


### PR DESCRIPTION
Add [GALA](https://github.com/martianoff/gala) to the Golang section.

GALA (Go Alternative Language) is a functional programming language that transpiles to Go. It adds sealed types, exhaustive pattern matching, immutability by default, monads (Option, Either, Try, Future), and immutable collections to the Go ecosystem.

- Apache 2.0 licensed
- Pre-built binaries for Linux, macOS, and Windows
- [Online playground](https://gala-playground.fly.dev)