### PR TITLE
Add rust-ppc-tiger — Rust to PowerPC assembly transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@
 * [JSweet](https://www.jsweet.org/) A transpiler from Java to TypeScript/JavaScript.
 * [GopherJS](https://github.com/gopherjs/gopherjs) A compiler from Go to JavaScript for running Go code in a browser.
 * [Dart2js](https://dart.dev/tools/dart2js) Use the dart2js tool to compile Dart code to deployable JavaScript.
+
+### PowerPC Assembly
+
+* [rust-ppc-tiger](https://github.com/Scottcjn/rust-ppc-tiger) Rust to PowerPC assembly transpiler targeting Mac OS X Tiger (10.4) and Leopard (10.5). Generates native PPC/AltiVec assembly from Rust source files.


### PR DESCRIPTION
Adds rust-ppc-tiger under a new "PowerPC Assembly" target language section.

**What is rust-ppc-tiger?**
- Transpiles Rust source code to native PowerPC assembly for Mac OS X Tiger (10.4) and Leopard (10.5)
- Generates PPC/AltiVec assembly from .rs files
- 73 .rs files → 73 .s files → native Mach-O PPC binary
- 660 runtime symbols, PIC stubs, and Tiger-compatible _NSGetArgc entry
- Successfully built and tested on a Power Mac G4 running Tiger 10.4.12

**Links:**
- Source: https://github.com/Scottcjn/rust-ppc-tiger
- Release: https://github.com/Scottcjn/rust-ppc-tiger/releases/tag/v0.1.0-ppc